### PR TITLE
Feature/path prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ $ catch2-compare reports-target reports-source
 
 You can have same one by running:
 ```sh
-$ catch2-compare sample/target sample/source
+$ catch2-compare --work-dir /path/to sample/target sample/source
 ```
 
 ```diff
-::: [test 1] test case A
-+++ /path/to/test-A.cpp:42
+@@ [test 1] test case A @@
+# test-A.cpp:42
 + benchmark a                       4ms          2ms     50.00%
 - benchmark b                       3ms          6ms   -100.00%
   benchmark c                        7s            -          -
@@ -39,12 +39,12 @@ $ catch2-compare sample/target sample/source
   benchmark f                         -       7h0m0s          -
 ≈ benchmark g                     999ns          1µs     -0.10%
 
-::: [test 1] test case C
-+++ /path/to/test-C.cpp:69
+@@ [test 1] test case C @@
+# test-C.cpp:69
   benchmark a                         -         13ns          -
 
-::: [test 3] test case A
-+++ /path/to/test-A.cpp:12
+@@ [test 3] test case A @@
+# test-A.cpp:12
   benchmark a                         -          11s          -
   Very long long benchm...            -      1h0m13s          -
 

--- a/cmd/catch2-compare/load.go
+++ b/cmd/catch2-compare/load.go
@@ -8,7 +8,7 @@ import (
 	"github.com/lesomnus/catch2-compare/internal/catch2"
 )
 
-func load(path string, reports map[string]catch2.XmlReport) error {
+func load(path string, reports map[string]catch2.Report) error {
 	fi, err := os.Stat(path)
 	if err != nil {
 		return err
@@ -39,7 +39,7 @@ func load(path string, reports map[string]catch2.XmlReport) error {
 		return err
 	}
 
-	var report catch2.XmlReport
+	var report catch2.Report
 	if err := xml.Unmarshal(data, &report); err != nil {
 		return err
 	}

--- a/cmd/catch2-compare/main.go
+++ b/cmd/catch2-compare/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/lesomnus/catch2-compare/internal/catch2"
 )
@@ -14,12 +15,48 @@ func usage() {
 	flag.PrintDefaults()
 }
 
-func run() int {
+func verifyArgs(opts Options) error {
+	if opts.WorkingDirectory != "" {
+		if wd, err := filepath.Abs(opts.WorkingDirectory); err != nil {
+			return fmt.Errorf("failed to resolve absolute path from %s: %w", opts.WorkingDirectory, err)
+		} else {
+			opts.WorkingDirectory = wd
+		}
+	}
+
+	if flag.NArg() != 2 {
+		return fmt.Errorf("expected 2 arguments but it was %d", flag.NArg())
+	}
+
+	return nil
+}
+
+type Options struct {
+	WorkingDirectory string
+}
+
+func main() {
+	opts := Options{
+		WorkingDirectory: "",
+	}
+
+	flag.StringVar(&opts.WorkingDirectory, "working-dir", "", "Display the file path relative to this path if possible")
+
+	flag.Usage = usage
+	flag.Parse()
+
+	if err := verifyArgs(opts); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+
+		flag.Usage()
+		os.Exit(1)
+	}
+
 	tgt_path := flag.Arg(0)
 	src_path := flag.Arg(1)
 
-	tgt_reports := make(map[string]catch2.XmlReport)
-	src_reports := make(map[string]catch2.XmlReport)
+	tgt_reports := make(map[string]catch2.Report)
+	src_reports := make(map[string]catch2.Report)
 
 	if err := load(tgt_path, tgt_reports); err != nil {
 		log.Fatalln("failed to load target report:", err)
@@ -28,32 +65,24 @@ func run() int {
 		log.Fatalln("failed to load source report:", err)
 	}
 
+	if opts.WorkingDirectory != "" {
+		// Make relative path.
+		mkRel := func(reports map[string]catch2.Report) {
+			for _, report := range reports {
+				for i, tc := range report.TestCases {
+					if rel, err := filepath.Rel(opts.WorkingDirectory, tc.Filename); err != nil {
+						continue
+					} else {
+						report.TestCases[i].Filename = rel
+					}
+				}
+			}
+		}
+
+		mkRel(tgt_reports)
+		mkRel(src_reports)
+	}
+
 	r := DiffReporter{}
 	r.Report(os.Stdout, tgt_reports, src_reports)
-
-	return 0
-}
-
-func verifyArgs() error {
-	if flag.NArg() != 2 {
-		return fmt.Errorf("expected 2 arguments but it was %d", flag.NArg())
-	}
-
-	return nil
-}
-
-func main() {
-	flag.Usage = usage
-	flag.Parse()
-
-	if err := verifyArgs(); err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-
-		flag.Usage()
-	}
-
-	ec := run()
-	if ec != 0 {
-		os.Exit(ec)
-	}
 }

--- a/cmd/catch2-compare/reporter.go
+++ b/cmd/catch2-compare/reporter.go
@@ -11,12 +11,12 @@ import (
 )
 
 type Reporter interface {
-	Report(w io.Writer, target map[string]catch2.XmlReport, source map[string]catch2.XmlReport) error
+	Report(w io.Writer, target map[string]catch2.Report, source map[string]catch2.Report) error
 }
 
 type DiffReporter struct{}
 
-func (r *DiffReporter) Report(w io.Writer, target map[string]catch2.XmlReport, source map[string]catch2.XmlReport) error {
+func (r *DiffReporter) Report(w io.Writer, target map[string]catch2.Report, source map[string]catch2.Report) error {
 	names := make([]string, 0, len(source))
 	for name := range source {
 		names = append(names, name)
@@ -29,7 +29,7 @@ func (r *DiffReporter) Report(w io.Writer, target map[string]catch2.XmlReport, s
 		srcReport := source[name]
 		tgtReport, ok := target[name]
 		if !ok {
-			tgtReport = catch2.XmlReport{
+			tgtReport = catch2.Report{
 				Name:      name,
 				TestCases: make([]catch2.TestCase, 0),
 			}

--- a/cmd/catch2-compare/reporter.go
+++ b/cmd/catch2-compare/reporter.go
@@ -92,10 +92,10 @@ func (r *DiffReporter) printTestCase(w io.Writer, target catch2.TestCase, source
 		panic(fmt.Sprintf("test case names do not match: %s != %s", target.Name, source.Name))
 	}
 
-	if _, err := fmt.Fprintln(w, "::: "+target.Name); err != nil {
+	if _, err := fmt.Fprintf(w, "@@ %s @@\n", target.Name); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintf(w, "+++ %s:%d\n", target.Filename, target.Line); err != nil {
+	if _, err := fmt.Fprintf(w, "# %s:%d\n", target.Filename, target.Line); err != nil {
 		return err
 	}
 	if target.Filename != source.Filename || target.Line != source.Line {

--- a/cmd/catch2-compare/reporter_test.go
+++ b/cmd/catch2-compare/reporter_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestDiffReporter(t *testing.T) {
-	tgt := map[string]catch2.XmlReport{
+	tgt := map[string]catch2.Report{
 		"test 1": {
 			Name: "test 1",
 			TestCases: []catch2.TestCase{
@@ -88,7 +88,7 @@ func TestDiffReporter(t *testing.T) {
 		},
 	}
 
-	src := map[string]catch2.XmlReport{
+	src := map[string]catch2.Report{
 		"test 1": {
 			Name: "test 1",
 			TestCases: []catch2.TestCase{

--- a/cmd/catch2-compare/reporter_test.go
+++ b/cmd/catch2-compare/reporter_test.go
@@ -177,8 +177,8 @@ func TestDiffReporter(t *testing.T) {
 	}
 
 	expected := `
-::: [test 1] test case A
-+++ /path/to/test-A.cpp:42
+@@ [test 1] test case A @@
+# /path/to/test-A.cpp:42
 + benchmark a                       4ms          2ms     50.00%
 - benchmark b                       3ms          6ms   -100.00%
   benchmark c                        7s            -          -
@@ -187,12 +187,12 @@ func TestDiffReporter(t *testing.T) {
   benchmark f                         -       7h0m0s          -
 ≈ benchmark g                     999ns          1µs     -0.10%
 
-::: [test 1] test case C
-+++ /path/to/test-C.cpp:69
+@@ [test 1] test case C @@
+# /path/to/test-C.cpp:69
   benchmark a                         -         13ns          -
 
-::: [test 3] test case A
-+++ /path/to/test-A.cpp:12
+@@ [test 3] test case A @@
+# /path/to/test-A.cpp:12
   benchmark a                         -          11s          -
   Very long long benchm...            -      1h0m13s          -
 `

--- a/internal/catch2/report.go
+++ b/internal/catch2/report.go
@@ -20,7 +20,7 @@ type TestCase struct {
 	BenchmarkResults []BenchmarkResult `xml:"BenchmarkResults"`
 }
 
-type XmlReport struct {
+type Report struct {
 	Name    string `xml:"name,attr"`
 	Version string `xml:"catch2-version,attr"`
 

--- a/internal/catch2/report_test.go
+++ b/internal/catch2/report_test.go
@@ -34,7 +34,7 @@ const data = `
 
 func TestUnmarshal(t *testing.T) {
 	require := require.New(t)
-	expected := catch2.XmlReport{
+	expected := catch2.Report{
 		Name:    "test_build",
 		Version: "3.1.0",
 		TestCases: []catch2.TestCase{{
@@ -64,7 +64,7 @@ func TestUnmarshal(t *testing.T) {
 		}},
 	}
 
-	var actual catch2.XmlReport
+	var actual catch2.Report
 
 	err := xml.Unmarshal([]byte(data), &actual)
 	require.NoError(err)


### PR DESCRIPTION
Closes #1; implemented as `--working-dir` instead of `--filepath-prefix`.

Fixes program to exit if required positional arguments are not given.